### PR TITLE
ci: add workflow to maintain interaction limits

### DIFF
--- a/.github/workflows/maintain-interaction-limits.yml
+++ b/.github/workflows/maintain-interaction-limits.yml
@@ -1,0 +1,22 @@
+name: Maintain Interaction Limits
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+
+jobs:
+  refresh-limits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refresh interaction limits
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl -s -X PUT \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/interaction-limits \
+            -d '{"limit":"collaborators_only","expiry":"six_months"}'
+          echo "✅ Interaction limits refreshed"


### PR DESCRIPTION
## Summary

Adds a GitHub Action that runs monthly to refresh the repository's interaction limits before they expire.

## What it does

- Sets interaction limits to **collaborators_only** (prevents random users from creating issues/PRs)
- Runs on the 1st of each month
- Uses 6-month expiry, refreshed monthly so it never lapses
- Can also be triggered manually via workflow_dispatch

## Why

Interaction limits are temporary (max 6 months). This ensures the repo stays protected permanently without manual intervention.

## Current Status

Interaction limits refreshed via API:
- Limit: `collaborators_only`
- Expires: `2026-08-01`

This workflow will refresh it before expiry.